### PR TITLE
calculation of throughput

### DIFF
--- a/client.c
+++ b/client.c
@@ -34,6 +34,7 @@ int g_nloop;
 int g_nhello;
 int g_noverwrap;
 int g_resolve;
+int success;
 long g_restimes[1000001];
 
 pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -102,7 +103,7 @@ void* do_connect(struct addrinfo *servinfo)
 
     pthread_mutex_lock(&g_mutex);
     pthread_mutex_unlock(&g_mutex);
-
+    success = 0;
     for (i = 0; i < g_nloop; ++i) {
         // loop through all the results and connect to the first we can
         if (servinfo) {
@@ -149,7 +150,9 @@ void* do_connect(struct addrinfo *servinfo)
                 }
                 if (numbytes != 6) {
                     printf("Recieved %d bytes\n", numbytes);
+                    goto exit;
                 }
+                success += 1;
             }
         {
             clock_gettime(CLOCK_MONOTONIC, &t2);
@@ -299,7 +302,7 @@ int main(int argc, char *argv[])
         show_restimes();
 
     printf("Throughput: %.2lf [#/sec]\n",
-            (g_nloop*g_nhello*g_noverwrap*nthread)*1000000000.0/(time_consumed));
+            (success)*1000000000.0/(time_consumed));
 
     return 0;
 }


### PR DESCRIPTION
Hi, 

Thanks for the work and your scripts. I have been looking at the results and they where really surprising. After looking a little closer I noticed that even running the client without a server reports an insanely hight throughput. This is of course not correct. 

In this patch, I only calculate the correct replies. This greatly influences the obtained results. Ie, if I only benchmark the correct results you will see that Gevent is actually faster than Tornado: 

Results for Tornado: 

$ ./client -v -n1 -h10000 -c100 -p5000 localhost
<  200 [us]: 1
<  300 [us]: 10
<  400 [us]: 17
<  500 [us]: 23
<  600 [us]: 8
<  700 [us]: 27
<  800 [us]: 6
<  900 [us]: 20
< 1000 [us]: 41
<    2 [ms]: 582
<    3 [ms]: 951
<    4 [ms]: 973174
<    5 [ms]: 4951
<    6 [ms]: 11169
<    7 [ms]: 2056
<    8 [ms]: 64
<   10 [ms]: 37
<   20 [ms]: 6863

> = 10sec: 0
> Throughput: 28125.89 [#/sec]

Results for Gevent: 

$ ./client -v -n1 -h10000 -c100 -p5000 localhost
<   30 [us]: 892375
<   40 [us]: 30430
<   50 [us]: 7038
<   60 [us]: 1127
<   70 [us]: 370
<   80 [us]: 161
<   90 [us]: 123
<  100 [us]: 199
<  200 [us]: 355
<  300 [us]: 242
<  400 [us]: 126
<  500 [us]: 115
<  600 [us]: 93
<  700 [us]: 59
<  800 [us]: 73
<  900 [us]: 76
< 1000 [us]: 64
<    2 [ms]: 745
<    3 [ms]: 985
<    4 [ms]: 729
<    5 [ms]: 434
<    6 [ms]: 570
<    7 [ms]: 621
<    8 [ms]: 566
<    9 [ms]: 593
<   10 [ms]: 409
<   20 [ms]: 9409
<   30 [ms]: 12382
<   40 [ms]: 21343
<   50 [ms]: 11601
<   60 [ms]: 4125
<   70 [ms]: 1915
<   80 [ms]: 343
<   90 [ms]: 192
<  100 [ms]: 12

> = 10sec: 0
> Throughput: 33471.75 [#/sec]

In the supplied patch I do not do anything to guard against race conditions on the incremental counter, you might want to guard against that.

Cheers,
Nicholas
